### PR TITLE
Fix: Multicert renew_hook placement

### DIFF
--- a/tasks/multicert_hook.yml
+++ b/tasks/multicert_hook.yml
@@ -15,5 +15,6 @@
     path: "/etc/letsencrypt/renewal/{{ item.domain }}.conf"
     line: "renew_hook = /usr/local/bin/hook_{{ item.domain }}.sh"
     regexp: "^# renew_hook ="
+    insertbefore: "[[webroot_map]]"
   when:
     - item.renew_hook is defined


### PR DESCRIPTION
The key renew_hook may be misplaced, need to setup before webroot_map