### PR TITLE
fix: renew_hook should be stored at the right place

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,7 @@
     path: "/etc/letsencrypt/renewal/{{ certbot__config.domain }}.conf"
     line: "renew_hook = /usr/local/bin/hook_{{ certbot__config.domain }}.sh"
     regexp: "^# renew_hook ="
+    insertbefore: '[[webroot_map]]'
   when:
     - certbot__install
     - certbot__configure


### PR DESCRIPTION
Sometimes, it's written on the bottom of the file, in the bad section, leading to a letsencrypt renew error