### PR TITLE
Feat: Allow run check mode to verify cert

### DIFF
--- a/tasks/multicert.yml
+++ b/tasks/multicert.yml
@@ -3,6 +3,7 @@
   stat:
     path: "/etc/letsencrypt/live/{{ item.domain }}/cert.pem"
   register: certif
+  check_mode: false
 
 - name: Obtain multiple initial certificate
   shell: "certbot certonly -n --webroot -w {{ item.rootdir }} --agree-tos -d {{ item.domain }} -m {{ item.alert_email }}"


### PR DESCRIPTION
Because it's only checking the filesystem, this can be run on check mode